### PR TITLE
Add stubbed VideoMAE encoder toggle and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,11 @@ Environment variables can be used to control runtime behaviour:
 | `ZEROCOPY_API_PORT` | API port | `8080` |
 | `ZEROCOPY_CORS_ALLOW_ORIGIN` | Optional single CORS origin | _unset_ |
 | `ZEROCOPY_CORS_ALLOW_ORIGINS` | Comma-separated list of CORS origins | _unset_ |
+| `ZEROCOPY_VIDEOMAE_ENABLED` | Enable downloading and using the real VideoMAE encoder weights | `true` |
+
+Setting `ZEROCOPY_VIDEOMAE_ENABLED=false` keeps the API responsive in environments without
+access to the Hugging Face model hub by falling back to a deterministic stub encoder that
+maintains a compatible embedding dimensionality for the FAISS index.
 
 ### Frontend Console
 

--- a/src/zerocopy/config.py
+++ b/src/zerocopy/config.py
@@ -50,6 +50,13 @@ class IndexConfig:
 
 
 @dataclass(slots=True)
+class ModelConfig:
+    """Configuration for ML models used by the service."""
+
+    videomae_enabled: bool = os.getenv("ZEROCOPY_VIDEOMAE_ENABLED", "true").lower() == "true"
+
+
+@dataclass(slots=True)
 class ApiConfig:
     host: str = os.getenv("ZEROCOPY_API_HOST", "0.0.0.0")
     port: int = int(os.getenv("ZEROCOPY_API_PORT", "8080"))
@@ -61,6 +68,7 @@ class ApiConfig:
 class ZerocopyConfig:
     storage: StorageConfig = field(default_factory=StorageConfig)
     index: IndexConfig = field(default_factory=IndexConfig)
+    models: ModelConfig = field(default_factory=ModelConfig)
     api: ApiConfig = field(default_factory=ApiConfig)
 
 

--- a/tests/test_api_deps.py
+++ b/tests/test_api_deps.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+
+def _reload_modules():
+    import zerocopy.config as config_module
+    import zerocopy.models.videomae_encoder as encoder_module
+    import zerocopy.api.deps as deps_module
+
+    importlib.reload(config_module)
+    importlib.reload(encoder_module)
+    importlib.reload(deps_module)
+    deps_module.reset_dependencies()
+    return config_module, encoder_module, deps_module
+
+
+def test_get_faiss_store_uses_stub_when_disabled(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZEROCOPY_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("ZEROCOPY_VIDEOMAE_ENABLED", "false")
+
+    _, encoder_module, deps_module = _reload_modules()
+
+    store = deps_module.get_faiss_store()
+    assert store.dim == encoder_module.VideoMAEEncoder.DEFAULT_EMBEDDING_DIM
+
+    encoder = deps_module.get_videomae_encoder()
+    assert encoder.use_stub is True
+    assert encoder.embedding_dim == encoder_module.VideoMAEEncoder.DEFAULT_EMBEDDING_DIM
+
+    deps_module.reset_dependencies()
+
+
+def test_get_faiss_store_real_path(monkeypatch, tmp_path):
+    monkeypatch.setenv("ZEROCOPY_DATA_DIR", str(tmp_path))
+    monkeypatch.delenv("ZEROCOPY_VIDEOMAE_ENABLED", raising=False)
+
+    class FakeAutoImageProcessor:
+        @classmethod
+        def from_pretrained(cls, model_name: str):
+            return cls()
+
+        def __call__(self, frames, return_tensors="pt"):
+            frame_list = list(frames)
+            tensor = torch.ones(1, len(frame_list), 3, 2, 2)
+            return {"pixel_values": tensor}
+
+    class FakeVideoMAEModel(torch.nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.config = SimpleNamespace(hidden_size=12, num_frames=4)
+            self._device = torch.device("cpu")
+
+        @classmethod
+        def from_pretrained(cls, model_name: str):
+            return cls()
+
+        def to(self, device):
+            self._device = torch.device(device)
+            return self
+
+        def eval(self):
+            return self
+
+        def forward(self, *, pixel_values):
+            batch, _, _, _height, _width = pixel_values.shape
+            hidden = torch.zeros(batch, self.config.num_frames + 1, self.config.hidden_size)
+            hidden[:, 0, :] = torch.arange(1, self.config.hidden_size + 1, dtype=torch.float32)
+            return SimpleNamespace(last_hidden_state=hidden)
+
+    fake_transformers = types.ModuleType("transformers")
+    fake_transformers.AutoImageProcessor = FakeAutoImageProcessor
+    fake_transformers.VideoMAEModel = FakeVideoMAEModel
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    _, encoder_module, deps_module = _reload_modules()
+
+    store = deps_module.get_faiss_store()
+    assert store.dim == FakeVideoMAEModel().config.hidden_size
+
+    encoder = deps_module.get_videomae_encoder()
+    assert encoder.use_stub is False
+    assert encoder.embedding_dim == FakeVideoMAEModel().config.hidden_size
+
+    frames = [np.zeros((2, 2, 3), dtype=np.uint8) for _ in range(4)]
+    embedding = encoder.encode(frames)
+    assert embedding.shape == (FakeVideoMAEModel().config.hidden_size,)
+
+    deps_module.reset_dependencies()

--- a/tests/test_videomae_encoder.py
+++ b/tests/test_videomae_encoder.py
@@ -96,3 +96,19 @@ def test_read_video_frames_rgb_missing(tmp_path):
     missing = tmp_path / "missing.mp4"
     with pytest.raises(FileNotFoundError):
         read_video_frames_rgb(missing)
+
+
+def test_stub_encoder_is_deterministic():
+    frames = [np.zeros((2, 2, 3), dtype=np.uint8) for _ in range(4)]
+    encoder = VideoMAEEncoder(use_stub=True)
+    encoder.load()
+
+    embedding_a = encoder.encode(frames)
+    embedding_b = encoder.encode(frames)
+    assert embedding_a.shape == (encoder.embedding_dim,)
+    np.testing.assert_allclose(embedding_a, embedding_b)
+
+    altered = frames.copy()
+    altered[0] = np.ones((2, 2, 3), dtype=np.uint8)
+    embedding_c = encoder.encode(altered)
+    assert not np.allclose(embedding_a, embedding_c)


### PR DESCRIPTION
## Summary
- add a configuration flag to select the stub VideoMAE encoder without loading large weights
- update the encoder and dependency wiring to fall back to a deterministic stub when models are unavailable
- document the new toggle and cover both stubbed and real dependency paths with tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2ab734e60832db95729c9883a916b